### PR TITLE
Add Scans Per Read Field to LabJack Configuration in NATS and Dashboard

### DIFF
--- a/dashboard/setup_nats.sh
+++ b/dashboard/setup_nats.sh
@@ -124,7 +124,8 @@ create_sample_data() {
                     "labjack_name": "Main Sensor Hub",
                     "serial": "TEST001",
                     "sensor_settings": {
-                        "sampling_rate": 1000,
+                        "sampling_rate": 10000,
+                        "scans_per_read": 1000,
                         "channels_enabled": [1, 2, 3],
                         "gains": 1,
                         "data_formats": ["voltage", "temperature", "pressure"],
@@ -142,7 +143,8 @@ create_sample_data() {
                     "labjack_name": "Environmental Monitor",
                     "serial": "TEST002",
                     "sensor_settings": {
-                        "sampling_rate": 500,
+                        "sampling_rate": 5000,
+                        "scans_per_read": 1000,
                         "channels_enabled": [1, 2],
                         "gains": 2,
                         "data_formats": ["temperature", "humidity"],
@@ -160,7 +162,8 @@ create_sample_data() {
                     "labjack_name": "Traffic Sensor",
                     "serial": "TEST003",
                     "sensor_settings": {
-                        "sampling_rate": 100,
+                        "sampling_rate": 2000,
+                        "scans_per_read": 1000,
                         "channels_enabled": [1, 4, 5],
                         "gains": 1,
                         "data_formats": ["voltage", "digital", "digital"],

--- a/dashboard/src/lib/components/basic_modals/LabJackModal.svelte
+++ b/dashboard/src/lib/components/basic_modals/LabJackModal.svelte
@@ -7,6 +7,7 @@
   }
   type FormattedSensorSettings = {
     "sampling_rate": number;
+    "scans_per_read": number;
     "channels_enabled": boolean[];
     "gains": number;
     "data_formats": string[];
@@ -76,7 +77,7 @@
     </div>
 
     <!-- Basic Configuration -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
       <div class="space-y-2">
         <label for="serialNumber" class="block text-sm font-medium text-gray-300">Serial Number</label>
         <input 
@@ -99,6 +100,18 @@
           class="w-full px-4 py-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200" 
           bind:value={labjackEdit.sensor_settings.sampling_rate}
           placeholder="0"
+          disabled={readOnly}
+        />
+      </div>
+      
+      <div class="space-y-2">
+        <label for="scansPerRead" class="block text-sm font-medium text-gray-300">Scans Per Read</label>
+        <input 
+          id="scansPerRead"
+          type="number" 
+          class="w-full px-4 py-3 bg-gray-800/50 border border-gray-600/50 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:border-blue-500/50 transition-all duration-200" 
+          bind:value={labjackEdit.sensor_settings.scans_per_read}
+          placeholder="1000"
           disabled={readOnly}
         />
       </div>

--- a/dashboard/src/routes/config/lj-config/+page.svelte
+++ b/dashboard/src/routes/config/lj-config/+page.svelte
@@ -16,6 +16,7 @@
   }
   type SensorSettings = {
     "sampling_rate": number;
+    "scans_per_read": number;
     "channels_enabled": number[];
     "gains": number;
     "data_formats": string[];
@@ -33,6 +34,7 @@
   }
   type FormattedSensorSettings = {
     "sampling_rate": number;
+    "scans_per_read": number;
     "channels_enabled": boolean[];
     "gains": number;
     "data_formats": string[];
@@ -46,6 +48,7 @@
   //default values for above types
   const defaultSensorSettings = {
     "sampling_rate": 0,
+    "scans_per_read": 1000,
     "channels_enabled": [0],
     "gains": 0,
     "data_formats": [""],
@@ -57,6 +60,7 @@
   }
   const defaultFormattedSettings: FormattedSensorSettings = {
     "sampling_rate": 0,
+    "scans_per_read": 1000,
     "channels_enabled": [false],
     "gains": 0,
     "data_formats": [""],
@@ -365,6 +369,7 @@
 
     
     formattedSettings.sampling_rate = settings.sampling_rate;
+    formattedSettings.scans_per_read = settings.scans_per_read;
     formattedSettings.gains = settings.gains;
     formattedSettings.publish_summary_peaks = settings.publish_summary_peaks;
     formattedSettings.labjack_reset = false;
@@ -400,6 +405,7 @@
     let activeChannel = -1;
 
     labjack.sensor_settings.sampling_rate = settings.sampling_rate;
+    labjack.sensor_settings.scans_per_read = settings.scans_per_read;
     labjack.sensor_settings.gains = settings.gains;
     labjack.sensor_settings.publish_summary_peaks = settings.publish_summary_peaks;
     labjack.sensor_settings.labjack_reset = false;
@@ -676,6 +682,10 @@
               <div class="flex items-center justify-between p-4 bg-gray-800/30 rounded-lg border border-gray-700/50">
                 <span class="text-sm text-gray-400">Sampling Rate:</span>
                 <span class="text-sm font-medium text-white">{labjack.sensor_settings.sampling_rate} Hz</span>
+              </div>
+              <div class="flex items-center justify-between p-4 bg-gray-800/30 rounded-lg border border-gray-700/50">
+                <span class="text-sm text-gray-400">Scans Per Read:</span>
+                <span class="text-sm font-medium text-white">{labjack.sensor_settings.scans_per_read}</span>
               </div>
               <div class="flex items-center justify-between p-4 bg-gray-800/30 rounded-lg border border-gray-700/50">
                 <span class="text-sm text-gray-400">Gain:</span>


### PR DESCRIPTION
Overview
- Added a new "Scans Per Read" configuration field to the LabJack device configuration system, allowing users to specify the number of scans to read per operation. This field is positioned between "Sampling Rate (Hz)" and "Gain" in the edit modal, and displays in the device configuration cards on the main page.

Technical Changes

- Updated TypeScript types in both the main page and modal component to include the new field, modified data processing functions for proper serialization, and updated the bash script to include the field in sample data. The layout was also improved to display all four basic configuration fields (Serial Number, Sampling Rate, Scans Per Read, and Gain) in a single row for better space utilization.